### PR TITLE
Update 60-ombi.yaml

### DIFF
--- a/scripts/components/60-ombi.yaml
+++ b/scripts/components/60-ombi.yaml
@@ -9,6 +9,7 @@
     cpu_shares: 1024
     volumes:
       - /etc/localtime:/etc/localtime:ro
+      - /bin/netstat:/bin/netstat
       - ${CONFIGS}/Ombi:/config
       - ${GOOGLE}:/Media
     environment:


### PR DESCRIPTION
Allow netstat to run so that docker container is healthy