### PR TITLE
Update 02-netdata.yaml

### DIFF
--- a/scripts/components/02-netdata.yaml
+++ b/scripts/components/02-netdata.yaml
@@ -16,7 +16,7 @@
     volumes:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/run/docker.sock:/var/run/docker.sock:rw
       - /etc/localtime:/etc/localtime:ro
     environment:
       - PGID=999


### PR DESCRIPTION
new version of netdata requires RW on this mount - /var/run/docker.sock:/var/run/docker.sock:rw