### PR TITLE
Update 41-deluge.yaml

### DIFF
--- a/scripts/nginx/41-deluge.yaml
+++ b/scripts/nginx/41-deluge.yaml
@@ -21,7 +21,7 @@
       - PUID=${USERID}
       - PGID=${GROUPID}
       - TZ=${TIMEZONE}
-      - UMASK_SET=022
+      - UMASK=022
       - VIRTUAL_HOST=deluge.${MYDOMAIN}
       - VIRTUAL_PORT=8112
       - VIRTUAL_NETWORK=nginx-proxy


### PR DESCRIPTION
LOGS in Portainer:

You are using a legacy method of defining umask

please update your environment variable from UMASK_SET to UMASK

to keep the functionality after July 2021